### PR TITLE
Remove lib version from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pyopengl == 3.1.5
-PySide2 == 5.14.2
+pyopengl
+PySide2


### PR DESCRIPTION
Setting up virtualenv and installing the libs with specific version on requirements.txt ocorred an error, probably due to the different python versions.

Just installing the libs (without version) worked fine to me